### PR TITLE
Messaging with Guava EventBus

### DIFF
--- a/adele-application/src/main/java/com/microservicesteam/adele/AdeleApplication.java
+++ b/adele-application/src/main/java/com/microservicesteam/adele/AdeleApplication.java
@@ -3,7 +3,7 @@ package com.microservicesteam.adele;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.microservicesteam")
 public class AdeleApplication {
     public static void main(String[] args) {
         SpringApplication.run(AdeleApplication.class, args);

--- a/adele-messaging/pom.xml
+++ b/adele-messaging/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project-adele</artifactId>
+        <groupId>com.microservicesteam</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>adele-messaging</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/adele-messaging/readme.md
+++ b/adele-messaging/readme.md
@@ -1,5 +1,6 @@
-Possible configuration of listeners
+**Possible configuration of listeners**
 
+```java
 @Configuration
 public class EventListenerConfig {
 
@@ -17,3 +18,4 @@ public class EventListenerConfig {
         bEventListener.addConsumer(e -> System.out.println(e.eventType() + " 3"));
     }
 }
+```

--- a/adele-messaging/readme.txt
+++ b/adele-messaging/readme.txt
@@ -1,0 +1,19 @@
+Possible configuration of listeners
+
+@Configuration
+public class EventListenerConfig {
+
+    @Autowired
+    BookingRequestedEventListener rEventListener;
+
+    @Autowired
+    BookingCancelledEventListener bEventListener;
+
+
+    @PostConstruct
+    public void init(){
+        rEventListener.addConsumer(e -> System.out.println(e.eventType() + " 1"));
+        rEventListener.addConsumer(e -> System.out.println(e.eventType() + " 2"));
+        bEventListener.addConsumer(e -> System.out.println(e.eventType() + " 3"));
+    }
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/config/MessagingConfig.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/config/MessagingConfig.java
@@ -1,0 +1,17 @@
+package com.microservicesteam.adele.messaging.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.common.eventbus.EventBus;
+
+@Configuration
+public class MessagingConfig {
+
+    @Bean
+    EventBus eventBus() {
+        return new EventBus();
+    }
+
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/BookingCancelledEvent.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/BookingCancelledEvent.java
@@ -1,0 +1,20 @@
+package com.microservicesteam.adele.messaging.events;
+
+import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_CANCELLED;
+
+import org.immutables.value.Value;
+
+import com.microservicesteam.adele.messaging.events.ImmutableBookingCancelledEvent.Builder;
+
+@Value.Immutable
+public interface BookingCancelledEvent extends Event {
+
+    @Value.Derived
+    default EventType eventType() {
+        return BOOKING_CANCELLED;
+    }
+
+    static Builder builder(){
+        return ImmutableBookingCancelledEvent.builder();
+    }
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/BookingRequestedEvent.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/BookingRequestedEvent.java
@@ -1,0 +1,16 @@
+package com.microservicesteam.adele.messaging.events;
+
+import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_REQUESTED;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BookingRequestedEvent extends Event {
+
+    @Value.Derived
+    default EventType eventType() {
+        return BOOKING_REQUESTED;
+    }
+
+
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/Event.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/Event.java
@@ -1,0 +1,12 @@
+package com.microservicesteam.adele.messaging.events;
+
+import java.time.LocalDateTime;
+
+public interface Event {
+
+    Long id();
+
+    LocalDateTime timestamp();
+
+    EventType eventType();
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/EventType.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/events/EventType.java
@@ -1,0 +1,6 @@
+package com.microservicesteam.adele.messaging.events;
+
+public enum EventType {
+    BOOKING_REQUESTED,
+    BOOKING_CANCELLED
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListener.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListener.java
@@ -1,0 +1,21 @@
+package com.microservicesteam.adele.messaging.listeners;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.microservicesteam.adele.messaging.events.BookingCancelledEvent;
+
+@Component
+public class BookingCancelledEventListener extends EventListener<BookingCancelledEvent> {
+
+    protected BookingCancelledEventListener(EventBus eventBus) {
+        super(eventBus);
+    }
+
+    @Subscribe
+    public void handleEvent(BookingCancelledEvent event) {
+        this.consumers.forEach(eConsumer -> eConsumer.accept(event));
+    }
+
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListener.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListener.java
@@ -1,0 +1,21 @@
+package com.microservicesteam.adele.messaging.listeners;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.microservicesteam.adele.messaging.events.BookingRequestedEvent;
+
+@Component
+public class BookingRequestedEventListener extends EventListener<BookingRequestedEvent> {
+
+    protected BookingRequestedEventListener(EventBus eventBus) {
+        super(eventBus);
+    }
+
+    @Subscribe
+    public void handleEvent(BookingRequestedEvent event) {
+        this.consumers.forEach(eConsumer -> eConsumer.accept(event));
+    }
+
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/EventListener.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/EventListener.java
@@ -1,0 +1,32 @@
+package com.microservicesteam.adele.messaging.listeners;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.annotation.PostConstruct;
+
+import com.google.common.eventbus.EventBus;
+import com.microservicesteam.adele.messaging.events.Event;
+
+abstract class EventListener<E extends Event> {
+
+    private final EventBus eventBus;
+    final List<Consumer<E>> consumers = newArrayList();
+
+    EventListener(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    @PostConstruct
+    public void init() {
+        eventBus.register(this);
+        System.out.println("Instance created");
+    }
+
+    public void addConsumer(Consumer<E> consumer) {
+        this.consumers.add(consumer);
+    }
+
+}

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/EventListener.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/listeners/EventListener.java
@@ -22,7 +22,6 @@ abstract class EventListener<E extends Event> {
     @PostConstruct
     public void init() {
         eventBus.register(this);
-        System.out.println("Instance created");
     }
 
     public void addConsumer(Consumer<E> consumer) {

--- a/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/publishers/EventPublisher.java
+++ b/adele-messaging/src/main/java/com/microservicesteam/adele/messaging/publishers/EventPublisher.java
@@ -1,0 +1,20 @@
+package com.microservicesteam.adele.messaging.publishers;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.eventbus.EventBus;
+import com.microservicesteam.adele.messaging.events.Event;
+
+@Component
+public class EventPublisher {
+
+    private final EventBus eventBus;
+
+    public EventPublisher(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    public void publish(Event event) {
+        eventBus.post(event);
+    }
+}

--- a/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListenerTest.java
+++ b/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListenerTest.java
@@ -1,7 +1,8 @@
 package com.microservicesteam.adele.messaging.listeners;
 
-import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_CANCELLED;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,16 +17,18 @@ import com.microservicesteam.adele.messaging.events.BookingCancelledEvent;
 public class BookingCancelledEventListenerTest {
 
     private EventBus eventBus;
-    private String result = "";
 
     @Mock
     private BookingCancelledEvent BOOKING_CANCELLED_EVENT;
+
+    @Mock
+    private Consumer<BookingCancelledEvent> consumer;
 
     @Before
     public void setUp() throws Exception {
         eventBus = new EventBus();
         EventListener<BookingCancelledEvent> eventListener = new BookingCancelledEventListener(eventBus);
-        eventListener.addConsumer(event -> result = BOOKING_CANCELLED.name());
+        eventListener.addConsumer(consumer);
         eventBus.register(eventListener);
     }
 
@@ -33,6 +36,6 @@ public class BookingCancelledEventListenerTest {
     public void receiveBookingCancelledEvent() throws Exception {
         eventBus.post(BOOKING_CANCELLED_EVENT);
 
-        assertThat(result).isEqualTo(BOOKING_CANCELLED.name());
+        verify(consumer).accept(BOOKING_CANCELLED_EVENT);
     }
 }

--- a/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListenerTest.java
+++ b/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingCancelledEventListenerTest.java
@@ -1,0 +1,38 @@
+package com.microservicesteam.adele.messaging.listeners;
+
+import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_CANCELLED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.eventbus.EventBus;
+import com.microservicesteam.adele.messaging.events.BookingCancelledEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BookingCancelledEventListenerTest {
+
+    private EventBus eventBus;
+    private String result = "";
+
+    @Mock
+    private BookingCancelledEvent BOOKING_CANCELLED_EVENT;
+
+    @Before
+    public void setUp() throws Exception {
+        eventBus = new EventBus();
+        EventListener<BookingCancelledEvent> eventListener = new BookingCancelledEventListener(eventBus);
+        eventListener.addConsumer(event -> result = BOOKING_CANCELLED.name());
+        eventBus.register(eventListener);
+    }
+
+    @Test
+    public void receiveBookingCancelledEvent() throws Exception {
+        eventBus.post(BOOKING_CANCELLED_EVENT);
+
+        assertThat(result).isEqualTo(BOOKING_CANCELLED.name());
+    }
+}

--- a/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListenerTest.java
+++ b/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListenerTest.java
@@ -1,0 +1,38 @@
+package com.microservicesteam.adele.messaging.listeners;
+
+import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_REQUESTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.eventbus.EventBus;
+import com.microservicesteam.adele.messaging.events.BookingRequestedEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BookingRequestedEventListenerTest {
+
+    private EventBus eventBus;
+    private String result = "";
+
+    @Mock
+    private BookingRequestedEvent BOOKING_REQUESTED_EVENT;
+
+    @Before
+    public void setUp() throws Exception {
+        eventBus = new EventBus();
+        EventListener<BookingRequestedEvent> eventListener = new BookingRequestedEventListener(eventBus);
+        eventListener.addConsumer(event -> result = BOOKING_REQUESTED.name());
+        eventBus.register(eventListener);
+    }
+
+    @Test
+    public void receiveBookingCancelledEvent() throws Exception {
+        eventBus.post(BOOKING_REQUESTED_EVENT);
+
+        assertThat(result).isEqualTo(BOOKING_REQUESTED.name());
+    }
+}

--- a/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListenerTest.java
+++ b/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/listeners/BookingRequestedEventListenerTest.java
@@ -1,7 +1,8 @@
 package com.microservicesteam.adele.messaging.listeners;
 
-import static com.microservicesteam.adele.messaging.events.EventType.BOOKING_REQUESTED;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,16 +17,17 @@ import com.microservicesteam.adele.messaging.events.BookingRequestedEvent;
 public class BookingRequestedEventListenerTest {
 
     private EventBus eventBus;
-    private String result = "";
 
     @Mock
     private BookingRequestedEvent BOOKING_REQUESTED_EVENT;
+    @Mock
+    private Consumer<BookingRequestedEvent> consumer;
 
     @Before
     public void setUp() throws Exception {
         eventBus = new EventBus();
         EventListener<BookingRequestedEvent> eventListener = new BookingRequestedEventListener(eventBus);
-        eventListener.addConsumer(event -> result = BOOKING_REQUESTED.name());
+        eventListener.addConsumer(consumer);
         eventBus.register(eventListener);
     }
 
@@ -33,6 +35,6 @@ public class BookingRequestedEventListenerTest {
     public void receiveBookingCancelledEvent() throws Exception {
         eventBus.post(BOOKING_REQUESTED_EVENT);
 
-        assertThat(result).isEqualTo(BOOKING_REQUESTED.name());
+        verify(consumer).accept(BOOKING_REQUESTED_EVENT);
     }
 }

--- a/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/publishers/EventPublisherTest.java
+++ b/adele-messaging/src/test/java/com/microservicesteam/adele/messaging/publishers/EventPublisherTest.java
@@ -1,0 +1,35 @@
+package com.microservicesteam.adele.messaging.publishers;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.eventbus.EventBus;
+import com.microservicesteam.adele.messaging.events.Event;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EventPublisherTest {
+
+    @Mock
+    private Event event;
+    @Mock
+    private EventBus eventBus;
+
+    private EventPublisher eventPublisher;
+
+    @Before
+    public void setUp() {
+        eventPublisher = new EventPublisher(eventBus);
+    }
+
+    @Test
+    public void publishEvent() {
+        eventPublisher.publish(event);
+
+        verify(eventBus).post(event);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<module>adele-notification</module>
 		<module>adele-userprofile</module>
 		<module>adele-seating</module>
+		<module>adele-messaging</module>
 	</modules>
 
 	<name>project-adele</name>
@@ -30,6 +31,10 @@
 		<java.version>1.8</java.version>
 		<joda-time.version>2.9.7</joda-time.version>
 		<immutables.version>2.4.0</immutables.version>
+		<guava.version>21.0</guava.version>
+		<assertj-core.version>3.6.1</assertj-core.version>
+		<mockito-core.version>1.8.1-rc1</mockito-core.version>
+		<junit.version>4.12</junit.version>
 	</properties>
 
 	<dependencyManagement>
@@ -45,6 +50,33 @@
 				<artifactId>value</artifactId>
 				<version>${immutables.version}</version>
 				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>${guava.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>${assertj-core.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito-core.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
Guava EventBus is added to the project.

There is a general EventPublisher that can be used to publish messages.
For each event we need to implement a listener.

Pls note, the current solution encloses Guava EventBus dependency. Thanks to this organization no other modules needs to know about Messaging implementation details.

However it has a cons as well, messaging module needs to know about every event type in the domain. Going further we need to figure out how to handle events between separated modules. 