### PR TITLE
Cancel tickets and handle error cases

### DIFF
--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/exceptions/NoOperation.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/exceptions/NoOperation.java
@@ -1,0 +1,20 @@
+package com.microservicesteam.adele.ticketmaster.exceptions;
+
+import org.immutables.value.Value;
+
+import com.microservicesteam.adele.ticketmaster.commands.TicketsCommand;
+
+@Value.Immutable
+public interface NoOperation {
+
+    TicketsCommand sourceCommand();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableNoOperation.Builder {
+    }
+
+
+}

--- a/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/TicketMasterService.java
+++ b/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/TicketMasterService.java
@@ -2,7 +2,6 @@ package com.microservicesteam.adele.ticketmaster;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.springframework.stereotype.Service;
 
@@ -49,7 +48,7 @@ public class TicketMasterService extends EventBasedService {
     @Subscribe
     public void handleCommand(BookTickets command) {
         if (allTicketsFree(command)) {
-            bookTickets().accept(command);
+            bookTickets(command);
             eventBus.post(TicketsBooked.builder()
                     .bookingId(command.bookingId())
                     .addAllPositions(command.positions())
@@ -64,7 +63,7 @@ public class TicketMasterService extends EventBasedService {
     @Subscribe
     public void handleCommand(CancelTickets command) {
         if (allTicketsBooked(command)) {
-            cancelTickets().accept(command);
+            cancelTickets(command);
             eventBus.post(TicketsCancelled.builder()
                     .bookingId(command.bookingId())
                     .addAllPositions(command.positions())
@@ -101,8 +100,8 @@ public class TicketMasterService extends EventBasedService {
                                 .build()));
     }
 
-    private Consumer<BookTickets> bookTickets() {
-        return command -> command.positions().forEach(
+    private void bookTickets(BookTickets command) {
+        command.positions().forEach(
                 position -> ticketRepository.put(position,
                         BookedTicket.builder()
                                 .bookingId(command.bookingId())
@@ -110,8 +109,8 @@ public class TicketMasterService extends EventBasedService {
                                 .build()));
     }
 
-    private Consumer<CancelTickets> cancelTickets() {
-        return command -> command.positions().forEach(
+    private void cancelTickets(CancelTickets command) {
+        command.positions().forEach(
                 position -> {
                     if (ticketRepository.containsKey(position)) {
                         ticketRepository.replace(position,

--- a/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/TicketMasterService.java
+++ b/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/TicketMasterService.java
@@ -1,6 +1,7 @@
 package com.microservicesteam.adele.ticketmaster;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class TicketMasterService extends EventBasedService {
 
     @Subscribe
     public void handleCommand(CreateTickets command) {
-        if (ticketsNotExist(command)) {
+        if (positionsNotExist(command.positions())) {
             addTickets(command);
             eventBus.post(TicketsCreated.builder()
                     .addAllPositions(command.positions())
@@ -47,7 +48,7 @@ public class TicketMasterService extends EventBasedService {
 
     @Subscribe
     public void handleCommand(BookTickets command) {
-        if (allTicketsFree(command)) {
+        if (positionsFree(command.positions())) {
             bookTickets(command);
             eventBus.post(TicketsBooked.builder()
                     .bookingId(command.bookingId())
@@ -62,7 +63,7 @@ public class TicketMasterService extends EventBasedService {
 
     @Subscribe
     public void handleCommand(CancelTickets command) {
-        if (allTicketsBooked(command)) {
+        if (positionsBooked(command.positions())) {
             cancelTickets(command);
             eventBus.post(TicketsCancelled.builder()
                     .bookingId(command.bookingId())
@@ -75,19 +76,19 @@ public class TicketMasterService extends EventBasedService {
         }
     }
 
-    private boolean ticketsNotExist(CreateTickets command) {
-        return command.positions().stream()
+    private boolean positionsNotExist(List<Position> positions) {
+        return positions.stream()
                 .noneMatch(position -> ticketRepository.containsKey(position));
     }
 
-    private boolean allTicketsFree(BookTickets command) {
-        return command.positions().stream().allMatch(
+    private boolean positionsFree(List<Position> positions) {
+        return positions.stream().allMatch(
                 position -> ticketRepository.containsKey(position) &&
                         ticketRepository.get(position) instanceof FreeTicket);
     }
 
-    private boolean allTicketsBooked(CancelTickets command) {
-        return command.positions().stream().allMatch(
+    private boolean positionsBooked(List<Position> positions) {
+        return positions.stream().allMatch(
                 position -> ticketRepository.containsKey(position) &&
                         ticketRepository.get(position) instanceof BookedTicket);
     }

--- a/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/TicketMasterServiceTest.java
+++ b/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/TicketMasterServiceTest.java
@@ -14,6 +14,7 @@ import com.microservicesteam.adele.ticketmaster.commands.CreateTickets;
 import com.microservicesteam.adele.ticketmaster.events.TicketsBooked;
 import com.microservicesteam.adele.ticketmaster.events.TicketsCancelled;
 import com.microservicesteam.adele.ticketmaster.events.TicketsCreated;
+import com.microservicesteam.adele.ticketmaster.exceptions.NoOperation;
 import com.microservicesteam.adele.ticketmaster.model.BookedTicket;
 import com.microservicesteam.adele.ticketmaster.model.FreeTicket;
 import com.microservicesteam.adele.ticketmaster.model.Position;
@@ -58,6 +59,31 @@ public class TicketMasterServiceTest {
     }
 
     @Test
+    public void createTicketsCommandResultsInNoOperationException() throws Exception {
+
+        createTickets(POSITION_1, POSITION_2);
+        CreateTickets createTicketsCommand = createTickets(POSITION_1);
+
+        assertThat(ticketMasterService.ticketRepository)
+                .hasSize(2)
+                .contains(entry(POSITION_1, FreeTicket.builder()
+                                .position(POSITION_1)
+                                .build()),
+                        entry(POSITION_2, FreeTicket.builder()
+                                .position(POSITION_2)
+                                .build()));
+        assertThat(deadEventListener.deadEvents)
+                .extracting("event")
+                .containsExactly(
+                        TicketsCreated.builder()
+                                .addPositions(POSITION_1, POSITION_2)
+                                .build(),
+                        NoOperation.builder()
+                                .sourceCommand(createTicketsCommand)
+                                .build());
+    }
+
+    @Test
     public void bookTicketsCommandResultsInTicketsBookEvent() throws Exception {
         createTickets(POSITION_1, POSITION_2);
         bookTickets(POSITION_1);
@@ -80,6 +106,36 @@ public class TicketMasterServiceTest {
                         TicketsBooked.builder()
                                 .bookingId(BOOKING_ID)
                                 .addPositions(POSITION_1)
+                                .build());
+    }
+
+    @Test
+    public void bookTicketsCommandResultsInNoOperationException() throws Exception {
+        createTickets(POSITION_1, POSITION_2);
+        bookTickets(POSITION_1);
+        BookTickets bookTicketsCommand = bookTickets(POSITION_1);
+
+        assertThat(ticketMasterService.ticketRepository)
+                .hasSize(2)
+                .contains(entry(POSITION_1, BookedTicket.builder()
+                                .bookingId(BOOKING_ID)
+                                .position(POSITION_1)
+                                .build()),
+                        entry(POSITION_2, FreeTicket.builder()
+                                .position(POSITION_2)
+                                .build()));
+        assertThat(deadEventListener.deadEvents)
+                .extracting("event")
+                .containsExactly(
+                        TicketsCreated.builder()
+                                .addPositions(POSITION_1, POSITION_2)
+                                .build(),
+                        TicketsBooked.builder()
+                                .bookingId(BOOKING_ID)
+                                .addPositions(POSITION_1)
+                                .build(),
+                        NoOperation.builder()
+                                .sourceCommand(bookTicketsCommand)
                                 .build());
     }
 
@@ -113,23 +169,59 @@ public class TicketMasterServiceTest {
                                 .build());
     }
 
-    private void bookTickets(Position... positions) {
-        eventBus.post(BookTickets.builder()
-                .bookingId(BOOKING_ID)
-                .addPositions(positions)
-                .build());
+    @Test
+    public void cancelTicketsCommandResultsInNoOperationException() throws Exception {
+        createTickets(POSITION_1, POSITION_2);
+        bookTickets(POSITION_1);
+        CancelTickets cancelTicketsCommand = cancelTickets(POSITION_2);
+
+        assertThat(ticketMasterService.ticketRepository)
+                .hasSize(2)
+                .contains(entry(POSITION_1, BookedTicket.builder()
+                                .bookingId(BOOKING_ID)
+                                .position(POSITION_1)
+                                .build()),
+                        entry(POSITION_2, FreeTicket.builder()
+                                .position(POSITION_2)
+                                .build()));
+        assertThat(deadEventListener.deadEvents)
+                .extracting("event")
+                .containsExactly(
+                        TicketsCreated.builder()
+                                .addPositions(POSITION_1, POSITION_2)
+                                .build(),
+                        TicketsBooked.builder()
+                                .bookingId(BOOKING_ID)
+                                .addPositions(POSITION_1)
+                                .build(),
+                        NoOperation.builder()
+                                .sourceCommand(cancelTicketsCommand)
+                                .build());
     }
 
-    private void createTickets(Position... positions) {
-        eventBus.post(CreateTickets.builder()
-                .addPositions(positions)
-                .build());
-    }
-
-    private void cancelTickets(Position... positions) {
-        eventBus.post(CancelTickets.builder()
+    private BookTickets bookTickets(Position... positions) {
+        BookTickets bookTicketsCommand = BookTickets.builder()
                 .bookingId(BOOKING_ID)
                 .addPositions(positions)
-                .build());
+                .build();
+        eventBus.post(bookTicketsCommand);
+        return bookTicketsCommand;
+    }
+
+    private CreateTickets createTickets(Position... positions) {
+        CreateTickets createTicketsCommand = CreateTickets.builder()
+                .addPositions(positions)
+                .build();
+        eventBus.post(createTicketsCommand);
+        return createTicketsCommand;
+    }
+
+    private CancelTickets cancelTickets(Position... positions) {
+        CancelTickets cancelTicketsCommand = CancelTickets.builder()
+                .bookingId(BOOKING_ID)
+                .addPositions(positions)
+                .build();
+        eventBus.post(cancelTicketsCommand);
+        return cancelTicketsCommand;
     }
 }


### PR DESCRIPTION
**Happy case**
- [x] Handle CancelTickets command

**Error cases**
- [x] NoOperation event is created with a purpose to do nothing, holding the source command for tracing  
- [x] Handle CreateTickets command when tickets are already created
- [x] Handle BookTickets command when tickets are already booked
- [x] Handle CancelTickets command when tickets are already not booked

**Things I considered**
Commands contains multiple positions. We have two choices. Either we process all positions and reject the whole command even if only some of them are corrupt or we process positions one by one and reject only corrupt ones partially. I prefer to reject all of them considering the case when I wanna buy tickets for my family - we go together or we don't go. 