### PR TITLE
Introduce booking id generation at TicketMasterService

### DIFF
--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/BookTickets.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/BookTickets.java
@@ -4,7 +4,6 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface BookTickets extends TicketsCommand {
-    long bookingId();
 
     static Builder builder() {
         return new Builder();

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/CancelTickets.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/CancelTickets.java
@@ -4,7 +4,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface CancelTickets extends TicketsCommand {
-    long bookingId();
+    String bookingId();
 
     static Builder builder() {
         return new Builder();

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsBooked.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsBooked.java
@@ -4,7 +4,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface TicketsBooked extends TicketsEvent {
-    long bookingId();
+    String bookingId();
 
     static Builder builder() {
         return new Builder();

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCancelled.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCancelled.java
@@ -4,7 +4,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface TicketsCancelled extends TicketsEvent {
-    long bookingId();
+    String bookingId();
 
     static Builder builder() {
         return new Builder();

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/model/BookedTicket.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/model/BookedTicket.java
@@ -6,7 +6,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface BookedTicket extends Ticket {
-    long bookingId();
+    String bookingId();
 
     @Override
     default TicketStatus status() {

--- a/adele-ticket-master/pom.xml
+++ b/adele-ticket-master/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/BookingIdGenerator.java
+++ b/adele-ticket-master/src/main/java/com/microservicesteam/adele/ticketmaster/BookingIdGenerator.java
@@ -1,0 +1,9 @@
+package com.microservicesteam.adele.ticketmaster;
+
+import java.util.UUID;
+
+public class BookingIdGenerator {
+    String generateBookingId(){
+        return UUID.randomUUID().toString();
+    }
+}

--- a/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/BookingIdGeneratorTest.java
+++ b/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/BookingIdGeneratorTest.java
@@ -1,0 +1,25 @@
+package com.microservicesteam.adele.ticketmaster;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BookingIdGeneratorTest {
+
+    private BookingIdGenerator bookingIdGenerator;
+
+    @Before
+    public void setUp() throws Exception {
+        bookingIdGenerator = new BookingIdGenerator();
+    }
+
+    @Test
+    public void bookingIdIsRandom() throws Exception {
+        String bookingId_1 = bookingIdGenerator.generateBookingId();
+        String bookingId_2 = bookingIdGenerator.generateBookingId();
+
+        assertThat(bookingId_1).isNotEqualTo(bookingId_2);
+    }
+}

--- a/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/TicketMasterServiceTest.java
+++ b/adele-ticket-master/src/test/java/com/microservicesteam/adele/ticketmaster/TicketMasterServiceTest.java
@@ -2,9 +2,13 @@ package com.microservicesteam.adele.ticketmaster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.common.eventbus.EventBus;
 import com.microservicesteam.adele.messaging.listeners.DeadEventListener;
@@ -19,9 +23,10 @@ import com.microservicesteam.adele.ticketmaster.model.BookedTicket;
 import com.microservicesteam.adele.ticketmaster.model.FreeTicket;
 import com.microservicesteam.adele.ticketmaster.model.Position;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TicketMasterServiceTest {
 
-    private static final long BOOKING_ID = 1L;
+    private static final String BOOKING_ID = "abc-123";
     private static final Position POSITION_1 = Position.builder().sectorId(1).id(1).eventId(1).build();
     private static final Position POSITION_2 = Position.builder().sectorId(1).id(2).eventId(1).build();
 
@@ -29,13 +34,18 @@ public class TicketMasterServiceTest {
     private EventBus eventBus;
     private DeadEventListener deadEventListener;
 
+    @Mock
+    private BookingIdGenerator bookingIdGenerator;
+
     @Before
     public void setUp() throws Exception {
         eventBus = new EventBus();
-        ticketMasterService = new TicketMasterService(eventBus);
+        ticketMasterService = new TicketMasterService(eventBus, bookingIdGenerator);
         ticketMasterService.init();
         deadEventListener = new DeadEventListener(eventBus);
         deadEventListener.init();
+
+        when(bookingIdGenerator.generateBookingId()).thenReturn(BOOKING_ID);
     }
 
     @Test
@@ -201,7 +211,6 @@ public class TicketMasterServiceTest {
 
     private BookTickets bookTickets(Position... positions) {
         BookTickets bookTicketsCommand = BookTickets.builder()
-                .bookingId(BOOKING_ID)
                 .addPositions(positions)
                 .build();
         eventBus.post(bookTicketsCommand);


### PR DESCRIPTION
@bearcheese 
Initially we planned to generate booking id in BookingService. In this case we would generate booking id even in case of failure in booking tickets if tickets are already booked. It might be useful for tracking unsuccessful booking trials, however we did not figure out them yet.

Therefore I moved id generation to TicketMaster service close to the ticket repo. In this case it will be generated only if tickets to book are available. 

I am not convinced yet about either of the places but I chose simplicity. 

Points to consider for a discussion:
- We want to track failed booking trials. I think it is not a question.
- Is statistics enough? I don't think so. If we don't create booking id for unsuccessful booking trial, all we have for a failed `bookTickets` event is a `noOperation`. That is enough for statistics only.
- Once a user clicks book button, how is she notified that tickets were booked successfully. 

We need a connection id. Thus -> initial idea was correct. 😄  
I convinced myself by the end of the description.