### PR TITLE
Polymorphic JSON serialization/deserialization on events

### DIFF
--- a/adele-ticket-master-api/pom.xml
+++ b/adele-ticket-master-api/pom.xml
@@ -32,6 +32,17 @@
             <artifactId>value</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsBooked.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsBooked.java
@@ -2,7 +2,14 @@ package com.microservicesteam.adele.ticketmaster.events;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutableTicketsBooked.class)
+@JsonDeserialize(as = ImmutableTicketsBooked.class)
+@JsonTypeName("TicketsBooked")
 public interface TicketsBooked extends TicketsEvent {
     String bookingId();
 

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCancelled.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCancelled.java
@@ -2,7 +2,14 @@ package com.microservicesteam.adele.ticketmaster.events;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutableTicketsCancelled.class)
+@JsonDeserialize(as = ImmutableTicketsCancelled.class)
+@JsonTypeName("TicketsCancelled")
 public interface TicketsCancelled extends TicketsEvent {
     String bookingId();
 

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCreated.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsCreated.java
@@ -2,12 +2,20 @@ package com.microservicesteam.adele.ticketmaster.events;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutableTicketsCreated.class)
+@JsonDeserialize(as = ImmutableTicketsCreated.class)
+@JsonTypeName("TicketsCreated")
 public interface TicketsCreated extends TicketsEvent {
 
     static Builder builder(){
         return new Builder();
     }
+
     class Builder extends ImmutableTicketsCreated.Builder {
     }
 }

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsEvent.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsEvent.java
@@ -2,9 +2,20 @@ package com.microservicesteam.adele.ticketmaster.events;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.microservicesteam.adele.messaging.events.Event;
 import com.microservicesteam.adele.ticketmaster.model.Position;
 
-interface TicketsEvent extends Event {
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME,
+        include=JsonTypeInfo.As.PROPERTY,
+        property="type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value=TicketsCreated.class, name="TicketsCreated"),
+        @JsonSubTypes.Type(value=TicketsBooked.class, name="TicketsBooked"),
+        @JsonSubTypes.Type(value=TicketsCancelled.class, name="TicketsCancelled"),
+        @JsonSubTypes.Type(value=TicketsPaid.class, name="TicketsPaid"),
+})
+public interface TicketsEvent extends Event {
     List<Position> positions();
 }

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsPaid.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/TicketsPaid.java
@@ -2,7 +2,14 @@ package com.microservicesteam.adele.ticketmaster.events;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutableTicketsPaid.class)
+@JsonDeserialize(as = ImmutableTicketsPaid.class)
+@JsonTypeName("TicketsPaid")
 public interface TicketsPaid extends TicketsEvent {
     String bookingId();
 

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/model/Position.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/model/Position.java
@@ -2,10 +2,17 @@ package com.microservicesteam.adele.ticketmaster.model;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutablePosition.class)
+@JsonDeserialize(as = ImmutablePosition.class)
 public interface Position {
     long eventId();
+
     int sectorId();
+
     int id();
 
     static Builder builder() {

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/AbstractSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/AbstractSerializationTest.java
@@ -1,0 +1,21 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import org.junit.Before;
+import org.springframework.boot.test.json.JacksonTester;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
+
+public class AbstractSerializationTest {
+
+    JacksonTester<TicketsEvent> json;
+
+    @Before
+    public void setUp() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new GuavaModule());
+        JacksonTester.initFields(this, objectMapper);
+    }
+
+}

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsBookedSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsBookedSerializationTest.java
@@ -9,7 +9,7 @@ import com.microservicesteam.adele.ticketmaster.events.TicketsBooked;
 import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
 import com.microservicesteam.adele.ticketmaster.model.Position;
 
-public class TicketsBookedSerializationTest extends AbstractSerializationTest{
+public class TicketsBookedSerializationTest extends AbstractSerializationTest {
 
     @Test
     public void serialize() throws Exception {
@@ -23,6 +23,7 @@ public class TicketsBookedSerializationTest extends AbstractSerializationTest{
                 .build();
 
         JsonContent<TicketsEvent> serializedJson = json.write(ticketsBooked);
+        assertThat(serializedJson).extractingJsonPathStringValue("type").isEqualTo("TicketsBooked");
         assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsBookedSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsBookedSerializationTest.java
@@ -1,0 +1,34 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+import com.microservicesteam.adele.ticketmaster.events.TicketsBooked;
+import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
+import com.microservicesteam.adele.ticketmaster.model.Position;
+
+public class TicketsBookedSerializationTest extends AbstractSerializationTest{
+
+    @Test
+    public void serialize() throws Exception {
+        TicketsBooked ticketsBooked = TicketsBooked.builder()
+                .bookingId("abc-123")
+                .addPositions(Position.builder()
+                        .eventId(1L)
+                        .sectorId(1)
+                        .id(1)
+                        .build())
+                .build();
+
+        JsonContent<TicketsEvent> serializedJson = json.write(ticketsBooked);
+        assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].id").isEqualTo(1);
+
+        assertThat(json.parse(serializedJson.getJson()))
+                .isEqualTo(ticketsBooked);
+    }
+}

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCancelledSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCancelledSerializationTest.java
@@ -1,0 +1,35 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+import com.microservicesteam.adele.ticketmaster.events.TicketsCancelled;
+import com.microservicesteam.adele.ticketmaster.events.TicketsCreated;
+import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
+import com.microservicesteam.adele.ticketmaster.model.Position;
+
+public class TicketsCancelledSerializationTest extends AbstractSerializationTest {
+
+    @Test
+    public void serialize() throws Exception {
+        TicketsCancelled ticketsCancelled = TicketsCancelled.builder()
+                .bookingId("abc-123")
+                .addPositions(Position.builder()
+                        .eventId(1L)
+                        .sectorId(1)
+                        .id(1)
+                        .build())
+                .build();
+
+        JsonContent<TicketsEvent> serializedJson = json.write(ticketsCancelled);
+        assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].id").isEqualTo(1);
+
+        assertThat(json.parse(serializedJson.getJson()))
+                .isEqualTo(ticketsCancelled);
+    }
+}

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCancelledSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCancelledSerializationTest.java
@@ -24,6 +24,7 @@ public class TicketsCancelledSerializationTest extends AbstractSerializationTest
                 .build();
 
         JsonContent<TicketsEvent> serializedJson = json.write(ticketsCancelled);
+        assertThat(serializedJson).extractingJsonPathStringValue("type").isEqualTo("TicketsCancelled");
         assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCreatedSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCreatedSerializationTest.java
@@ -22,6 +22,7 @@ public class TicketsCreatedSerializationTest extends AbstractSerializationTest {
                 .build();
 
         JsonContent<TicketsEvent> serializedJson = json.write(ticketsCreated);
+        assertThat(serializedJson).extractingJsonPathStringValue("type").isEqualTo("TicketsCreated");
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].id").isEqualTo(1);

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCreatedSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsCreatedSerializationTest.java
@@ -1,0 +1,32 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+import com.microservicesteam.adele.ticketmaster.events.TicketsCreated;
+import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
+import com.microservicesteam.adele.ticketmaster.model.Position;
+
+public class TicketsCreatedSerializationTest extends AbstractSerializationTest {
+
+    @Test
+    public void serialize() throws Exception {
+        TicketsCreated ticketsCreated = TicketsCreated.builder()
+                .addPositions(Position.builder()
+                        .eventId(1L)
+                        .sectorId(1)
+                        .id(1)
+                        .build())
+                .build();
+
+        JsonContent<TicketsEvent> serializedJson = json.write(ticketsCreated);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].id").isEqualTo(1);
+
+        assertThat(json.parse(serializedJson.getJson()))
+                .isEqualTo(ticketsCreated);
+    }
+}

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsPaidSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsPaidSerializationTest.java
@@ -5,12 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.springframework.boot.test.json.JsonContent;
 
-import com.microservicesteam.adele.ticketmaster.events.TicketsBooked;
 import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
 import com.microservicesteam.adele.ticketmaster.events.TicketsPaid;
 import com.microservicesteam.adele.ticketmaster.model.Position;
 
-public class TicketsPaidSerializationTest extends AbstractSerializationTest{
+public class TicketsPaidSerializationTest extends AbstractSerializationTest {
 
     @Test
     public void serialize() throws Exception {
@@ -24,6 +23,7 @@ public class TicketsPaidSerializationTest extends AbstractSerializationTest{
                 .build();
 
         JsonContent<TicketsEvent> serializedJson = json.write(ticketsPaid);
+        assertThat(serializedJson).extractingJsonPathStringValue("type").isEqualTo("TicketsPaid");
         assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
         assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsPaidSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/TicketsPaidSerializationTest.java
@@ -1,0 +1,35 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+import com.microservicesteam.adele.ticketmaster.events.TicketsBooked;
+import com.microservicesteam.adele.ticketmaster.events.TicketsEvent;
+import com.microservicesteam.adele.ticketmaster.events.TicketsPaid;
+import com.microservicesteam.adele.ticketmaster.model.Position;
+
+public class TicketsPaidSerializationTest extends AbstractSerializationTest{
+
+    @Test
+    public void serialize() throws Exception {
+        TicketsPaid ticketsPaid = TicketsPaid.builder()
+                .bookingId("abc-123")
+                .addPositions(Position.builder()
+                        .eventId(1L)
+                        .sectorId(1)
+                        .id(1)
+                        .build())
+                .build();
+
+        JsonContent<TicketsEvent> serializedJson = json.write(ticketsPaid);
+        assertThat(serializedJson).extractingJsonPathStringValue("bookingId").isEqualTo("abc-123");
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].eventId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].sectorId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.positions[0].id").isEqualTo(1);
+
+        assertThat(json.parse(serializedJson.getJson()))
+                .isEqualTo(ticketsPaid);
+    }
+}


### PR DESCRIPTION
Issue-25: Currently ticket events are serialized without a type information. 
- As a conclusion on the UI we are not able to distinguish between events and act accordingly. At the moment we handle every event as booked. 
- Later on on Kafka consumer we are not able to deserialize events without type information.

Result: type information is added to the events. Thus serialization <-> deserialization works.