### PR TITLE
Issue-76 CloseReservation command and ReservationClosed event added

### DIFF
--- a/adele-clerk/src/test/java/com/microservicesteam/adele/clerk/domain/ReservationsServiceTest.java
+++ b/adele-clerk/src/test/java/com/microservicesteam/adele/clerk/domain/ReservationsServiceTest.java
@@ -177,7 +177,7 @@ public class ReservationsServiceTest {
 
     @Test
     public void onReservationClosedEventTheEventIsPublished() {
-        ReservationClosed reservationRejected =
+        ReservationClosed reservationClosed =
                 ReservationClosed.builder()
                         .reservation(Reservation.builder()
                                 .reservationId(RESERVATION_ID)
@@ -185,13 +185,13 @@ public class ReservationsServiceTest {
                                 .build())
                         .build();
 
-        eventBus.post(reservationRejected);
+        eventBus.post(reservationClosed);
 
         verify(ticketRepository).put(Ticket.builder()
                 .status(SOLD)
                 .ticketId(TICKET_ID_1)
                 .build());
-        verify(webSocketEventPublisher).publishToSector(reservationRejected);
+        verify(webSocketEventPublisher).publishToSector(reservationClosed);
     }
 
 

--- a/adele-order-manager/pom.xml
+++ b/adele-order-manager/pom.xml
@@ -59,11 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
         </dependency>

--- a/adele-payment-manager/src/test/java/com/microservicesteam/adele/payment/PaymentManagerTest.java
+++ b/adele-payment-manager/src/test/java/com/microservicesteam/adele/payment/PaymentManagerTest.java
@@ -19,7 +19,6 @@ import com.microservicesteam.adele.payment.paypal.PaymentRequestMapper;
 import com.microservicesteam.adele.payment.paypal.PaymentResponseMapper;
 import com.microservicesteam.adele.payment.paypal.PaypalProxy;
 import com.paypal.api.payments.Payment;
-import com.paypal.api.payments.PaymentExecution;
 import com.paypal.base.rest.PayPalRESTException;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/CloseReservation.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/commands/CloseReservation.java
@@ -1,0 +1,19 @@
+package com.microservicesteam.adele.ticketmaster.commands;
+
+import org.immutables.value.Value;
+
+import com.microservicesteam.adele.ticketmaster.model.Reservation;
+
+@Value.Immutable
+public interface CloseReservation extends Command {
+
+    Reservation reservation();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableCloseReservation.Builder {
+    }
+
+}

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/Event.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/Event.java
@@ -10,7 +10,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value=TicketsCreated.class, name="TicketsCreated"),
         @JsonSubTypes.Type(value=ReservationAccepted.class, name="ReservationAccepted"),
         @JsonSubTypes.Type(value=ReservationCancelled.class, name="ReservationCancelled"),
-        @JsonSubTypes.Type(value=ReservationRejected.class, name="ReservationRejected")
+        @JsonSubTypes.Type(value=ReservationRejected.class, name="ReservationRejected"),
+        @JsonSubTypes.Type(value=ReservationClosed.class, name="ReservationClosed")
 })
 public interface Event {
 }

--- a/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/ReservationClosed.java
+++ b/adele-ticket-master-api/src/main/java/com/microservicesteam/adele/ticketmaster/events/ReservationClosed.java
@@ -1,0 +1,22 @@
+package com.microservicesteam.adele.ticketmaster.events;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableReservationClosed.class)
+@JsonDeserialize(as = ImmutableReservationClosed.class)
+@JsonTypeName("ReservationClosed")
+public interface ReservationClosed extends ReservationEvent {
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableReservationClosed.Builder {
+    }
+
+}

--- a/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/ReservationClosedSerializationTest.java
+++ b/adele-ticket-master-api/src/test/java/com/microserviceteam/adele/ticketmaster/events/ReservationClosedSerializationTest.java
@@ -1,0 +1,40 @@
+package com.microserviceteam.adele.ticketmaster.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+import com.microservicesteam.adele.ticketmaster.events.Event;
+import com.microservicesteam.adele.ticketmaster.events.ReservationClosed;
+import com.microservicesteam.adele.ticketmaster.model.Reservation;
+import com.microservicesteam.adele.ticketmaster.model.TicketId;
+
+public class ReservationClosedSerializationTest extends AbstractSerializationTest {
+
+    @Test
+    public void serialize() throws IOException {
+        ReservationClosed reservationClosed = ReservationClosed.builder()
+                .reservation(Reservation.builder()
+                        .reservationId("abc-123")
+                        .addTickets(TicketId.builder()
+                                .programId(1L)
+                                .sectorId(2)
+                                .seatId(3)
+                                .build())
+                        .build())
+                .build();
+
+        JsonContent<Event> serializedJson = json.write(reservationClosed);
+        assertThat(serializedJson).extractingJsonPathStringValue("type").isEqualTo("ReservationClosed");
+        assertThat(serializedJson).extractingJsonPathStringValue("$.reservation.reservationId").isEqualTo("abc-123");
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.reservation.tickets[0].programId").isEqualTo(1);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.reservation.tickets[0].sectorId").isEqualTo(2);
+        assertThat(serializedJson).extractingJsonPathNumberValue("$.reservation.tickets[0].seatId").isEqualTo(3);
+
+        assertThat(json.parse(serializedJson.getJson()))
+                .isEqualTo(reservationClosed);
+    }
+}


### PR DESCRIPTION
This PR is related to #76, `CloseReservation` command will be issued by `OrderManager` once the tickets are successfully paid and `TicketMaster` should be notified to mark those tickets as `SOLD`.

- [x] CloseReservation command and ReservationClosed event added
- [x] TicketMaster and clerk implementations adapted
- [x] minor fixes

